### PR TITLE
Add ability to specify IPs for device serial numbers in config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Fan state changes (e.g; FAN -> HEAT) are published ~immediately on change.
 ### Other Notes
 
 `libpurecool` by default uses a flavour of mDNS to automatically discover
-the Dyson fan. This is overridable (but this script doesn't at the moment).
+the Dyson fan. If automatic discovery isn't available on your network, it is possible
+to specify IP addresses mapped to device serial numbers in config.ini - see
+`config-sample.ini` for usage.
 
 ## Dashboard
 

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -3,3 +3,8 @@ username = yourusername
 password = yourpassword
 ; Two-letter country code where your account is registered.
 country = IE
+
+[Hosts]
+; Optional: provide an IP address for each of your device
+; serial numbers, if you are unable to use zeroconf discovery.
+AB1-UK-AAA0111A = 192.168.1.2


### PR DESCRIPTION
Hello! Thanks so much for creating this Prometheus exporter, it's super useful!

I've made a small change to allow manual specification of IP addresses, by looking them up by serial number from the config file.

For some reason zeroconfig doesn't detect my dyson device, but this exporter works fine when I tell it the IP