### PR TITLE
Fix reference to missing fan_mode property

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -280,9 +280,11 @@ class Metrics:
             fan_mode = 'AUTO'
         elif message.fan_power == const.FanPower.POWER_ON.value:
             fan_mode = 'FAN'
+        elif message.fan_power == const.FanPower.POWER_OFF.value:
+            pass
         else:
-            logging.warning('Received unknown fan_power setting from "%s" (serial=%s): %s, defaulting to "%s',
-                            name, serial, message.fan_mode, fan_mode)
+            logging.warning('Received unknown fan_power setting from "%s" (serial=%s): "%s", defaulting to "%s"',
+                            name, serial, message.fan_power, fan_mode)
         update_enum(self.fan_mode, name, serial, fan_mode)
 
         if isinstance(message, dyson_pure_state_v2.DysonPureHotCoolV2State):


### PR DESCRIPTION
Hello! I think this `fan_mode` property was mistakenly left in in a recent change, I've changed it to what I think is correct (`fan_power`)

I've also put in a case to match message.fan_power being `OFF`, because it seems a bit odd to emit a warning when the fan_power is `OFF`, as it looks like `Received unknown fan_power setting ... "OFF", defaulting to "OFF"`