### PR TITLE
Fix reconnect bug and add watchdog timer and bump to 0.4.1

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "bazel build ...",
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            }
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "command": "bazel test ...",
+            "group": {
+              "kind": "test",
+            }
+        },
+        {
+          "label": "Package",
+          "type": "shell",
+          "command": "bazel build :main-deb",
+      },
+    ]
+}

--- a/BUILD
+++ b/BUILD
@@ -124,5 +124,5 @@ pkg_deb(
     package = "prometheus-dyson",
     postrm = "debian/postrm",
     prerm = "debian/prerm",
-    version = "0.4.0",
+    version = "0.4.1",
 )

--- a/main.py
+++ b/main.py
@@ -28,54 +28,73 @@ def _sleep_forever() -> None:
 def main(argv):
     """Main body of the program."""
     parser = argparse.ArgumentParser(prog=argv[0])
-    parser.add_argument('--port', help='HTTP server port',
-                        type=int, default=8091)
+    parser.add_argument("--port", help="HTTP server port", type=int, default=8091)
     parser.add_argument(
-        '--config', help='Configuration file (INI file)', default='config.ini')
+        "--config", help="Configuration file (INI file)", default="config.ini"
+    )
     parser.add_argument(
-        '--log_level', help='Logging level (DEBUG, INFO, WARNING, ERROR)', type=str, default='INFO')
+        "--log_level",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR)",
+        type=str,
+        default="INFO",
+    )
     parser.add_argument(
-        '--include_inactive_devices',
-        help='Do not use; this flag has no effect and remains for compatibility only',
-        action='store_true')
+        "--watchdog_timeout_seconds",
+        help="Timeout to abort the process if exceeded (0 for no watchdog)",
+        type=int,
+        default=300,
+    )
+    parser.add_argument(
+        "--include_inactive_devices",
+        help="Do not use; this flag has no effect and remains for compatibility only",
+        action="store_true",
+    )
+
     args = parser.parse_args()
 
     try:
         level = getattr(logging, args.log_level)
     except AttributeError:
-        print(f'Invalid --log_level: {args.log_level}')
+        print(f"Invalid --log_level: {args.log_level}")
         sys.exit(-1)
     args = parser.parse_args()
 
     logging.basicConfig(
-        format='%(asctime)s [%(name)24s %(thread)d] %(levelname)10s %(message)s',
-        datefmt='%Y/%m/%d %H:%M:%S',
-        level=level)
+        format="%(asctime)s [%(name)24s %(thread)d] %(levelname)10s %(message)s",
+        datefmt="%Y/%m/%d %H:%M:%S",
+        level=level,
+    )
 
-    logger.info('Starting up on port=%s', args.port)
+    logger.info("Starting up on port=%s", args.port)
 
     if args.include_inactive_devices:
         logger.warning(
-            '--include_inactive_devices is now inoperative and will be removed in a future release')
+            "--include_inactive_devices is now inoperative and will be removed in a future release"
+        )
 
     try:
         cfg = config.Config(args.config)
     except:
-        logger.exception('Could not load configuration: %s', args.config)
+        logger.exception("Could not load configuration: %s", args.config)
         sys.exit(-1)
 
     devices = cfg.devices
     if len(devices) == 0:
         logger.fatal(
-            'No devices configured; please re-run this program with --create_device_cache.')
+            "No devices configured; please re-run this program with --create_device_cache."
+        )
         sys.exit(-2)
 
     prometheus_client.start_http_server(args.port)
-
-    connect.ConnectionManager(metrics.Metrics().update, devices, cfg.hosts)
+    connect.ConnectionManager(
+        metrics.Metrics().update,
+        devices,
+        cfg.hosts,
+        watchdog_secs=args.watchdog_timeout_seconds,
+    )
 
     _sleep_forever()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
We called disconnect() twice on the underlying libdyson object, which
resulted in an unhandled exception and the process hanging. Unfortunately
addressing this does not reliably result in reconnects; so also add a default
5 minute watchdog timer. If the timer expires, the process aborts so
systemd can restart it.

This PR also adds VSCode tasks and bumps version to 0.4.1.