### PR TITLE
Update dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("@pip//:requirements.bzl", "requirement")
+load("@pip_deps//:requirements.bzl", "requirement")
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
 py_library(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,44 +3,32 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Python rules.
 http_archive(
     name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
-    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+    sha256 = "a868059c8c6dd6ad45a205cca04084c652cfe1852e6df2d5aca036f6e5438380",
+    strip_prefix = "rules_python-0.14.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.14.0.tar.gz",
 )
 
-load("@rules_python//python:pip.bzl", "pip_install")
+load("@rules_python//python:pip.bzl", "pip_parse")
 
-pip_install(
-    # (Optional) You can provide extra parameters to pip.
-    # Here, make pip output verbose (this is usable with `quiet = False`).
-    #extra_pip_args = ["-v"],
-
-    # (Optional) You can exclude custom elements in the data section of the generated BUILD files for pip packages.
-    # Exclude directories with spaces in their names in this example (avoids build errors if there are such directories).
-    #pip_data_exclude = ["**/* */**"],
-
-    # (Optional) You can provide a python_interpreter (path) or a python_interpreter_target (a Bazel target, that
-    # acts as an executable). The latter can be anything that could be used as Python interpreter. E.g.:
-    # 1. Python interpreter that you compile in the build file (as above in @python_interpreter).
-    # 2. Pre-compiled python interpreter included with http_archive
-    # 3. Wrapper script, like in the autodetecting python toolchain.
-    #python_interpreter_target = "@python_interpreter//:python_bin",
-
-    # (Optional) You can set quiet to False if you want to see pip output.
-    #quiet = False,
-
-    # Uses the default repository name "pip"
-    requirements = "//:requirements.txt",
+pip_parse(
+    name = "pip_deps",
+    requirements_lock = "//:requirements.txt",
 )
+
+load("@pip_deps//:requirements.bzl", "install_deps")
+
+install_deps()
+
 
 # Packaging rules.
 #load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_pkg",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
     ],
-    sha256 = "038f1caa773a7e35b3663865ffb003169c6a71dc995e39bf4815792f385d837d",
+    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
 )
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()

--- a/misc/BUILD
+++ b/misc/BUILD
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("@pip//:requirements.bzl", "requirement")
+load("@pip_deps//:requirements.bzl", "requirement")
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
 py_binary(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,15 @@
-prometheus_client
-libdyson
+async-timeout==4.0.2
+attrs==22.1.0
+certifi==2022.9.24
+cffi==1.15.1
+charset-normalizer==2.1.1
+cryptography==38.0.3
+idna==3.4
+ifaddr==0.2.0
+libdyson==0.8.11
+paho-mqtt==1.6.1
+prometheus-client==0.15.0
+pycparser==2.21
+requests==2.28.1
+urllib3==1.26.13
+zeroconf==0.39.4


### PR DESCRIPTION
Looks like we've run out of time with the old versions of rules_python and rules_pkg for Bazel. Update these and freeze our Python dependencies (a new default requirement for rules_python it seems).